### PR TITLE
Feature/Handling Trying to add a pass twice

### DIFF
--- a/AppleWallet/UAWalletAction.m
+++ b/AppleWallet/UAWalletAction.m
@@ -119,7 +119,9 @@
         if (pass) {
             if ([self.passLibrary containsPass:pass]) {
                 UA_LDEBUG(@"Passbook library already contains the pass %@, skipping add", pass.localizedName);
-                completionHandler([UAActionResult resultWithValue:nil withFetchResult:UAActionFetchResultNewData]);
+                NSDictionary *userInfo = @{NSLocalizedDescriptionKey: NSLocalizedString(@"Passbook library already contains the pass", nil)};
+                NSError *error = [NSError errorWithDomain:@"UAWalletAction" code:9999 userInfo:userInfo];
+                completionHandler([UAActionResult resultWithError:error withFetchResult:UAActionFetchResultNoData]);
                 return;
             }
 


### PR DESCRIPTION
* Adding better error handling when a Pass already exists in the Wallet Library.

- When a user tries to add a pass and the pass already exists in the Wallet Library, throw a custom NSError that describes the situation and change the result to 'UAActionFetchResultNoData'